### PR TITLE
Add client-side Barcelona treasure hunt with GPS photo validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# hunt-for-secrets-website
+# Hunt for Secrets
+
+A client-side treasure hunt around Barcelona. Solve clues by visiting famous landmarks and uploading photos with GPS metadata. If the photo was taken near the expected location, you earn a point.
+
+## Running
+
+Just open `index.html` in a browser. No server is required.
+
+## How it works
+
+The page lists a set of locations. For each clue, upload a photo. The browser reads the image's GPS EXIF data and checks whether it was taken within 100 meters of the target location. Your score updates as you solve clues.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Barcelona Treasure Hunt</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/exif-js"></script>
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <h1>Barcelona Treasure Hunt</h1>
+  <div id="questions"></div>
+  <div id="score"></div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,85 @@
+const questions = [
+  {
+    id: 1,
+    name: 'Sagrada Família',
+    lat: 41.4036,
+    lon: 2.1744,
+    correct: false
+  },
+  {
+    id: 2,
+    name: 'Park Güell',
+    lat: 41.4145,
+    lon: 2.1527,
+    correct: false
+  }
+];
+
+const threshold = 100; // meters
+
+function dmsToDecimal(dms, ref) {
+  const [degrees, minutes, seconds] = dms;
+  let dec = degrees + minutes / 60 + seconds / 3600;
+  if (ref === 'S' || ref === 'W') dec = -dec;
+  return dec;
+}
+
+function getDistanceMeters(lat1, lon1, lat2, lon2) {
+  const toRad = deg => (deg * Math.PI) / 180;
+  const R = 6371000;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function handleFile(question, input, resultSpan) {
+  const file = input.files[0];
+  if (!file) return;
+
+  EXIF.getData(file, function () {
+    const lat = EXIF.getTag(this, 'GPSLatitude');
+    const latRef = EXIF.getTag(this, 'GPSLatitudeRef');
+    const lon = EXIF.getTag(this, 'GPSLongitude');
+    const lonRef = EXIF.getTag(this, 'GPSLongitudeRef');
+    if (lat && lon) {
+      const photoLat = dmsToDecimal(lat, latRef);
+      const photoLon = dmsToDecimal(lon, lonRef);
+      const dist = getDistanceMeters(photoLat, photoLon, question.lat, question.lon);
+      if (dist <= threshold) {
+        question.correct = true;
+        resultSpan.textContent = `Correct! (${dist.toFixed(1)} m)`;
+      } else {
+        resultSpan.textContent = `Not quite (${dist.toFixed(1)} m away)`;
+      }
+    } else {
+      resultSpan.textContent = 'No GPS data found';
+    }
+    updateScore();
+  });
+}
+
+function updateScore() {
+  const score = questions.filter(q => q.correct).length;
+  document.getElementById('score').textContent = `Score: ${score}/${questions.length}`;
+}
+
+function init() {
+  const container = document.getElementById('questions');
+  questions.forEach(q => {
+    const div = document.createElement('div');
+    div.className = 'question';
+    div.innerHTML = `<p>${q.name}</p><input type="file" accept="image/*" /> <span class="result"></span>`;
+    const input = div.querySelector('input');
+    const result = div.querySelector('.result');
+    input.addEventListener('change', () => handleFile(q, input, result));
+    container.appendChild(div);
+  });
+  updateScore();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+
+.question {
+  margin-bottom: 1.5rem;
+}
+
+.result {
+  margin-left: 1rem;
+}
+
+#score {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Create index page and scripts for a client-only treasure hunt in Barcelona
- Validate uploaded photo GPS metadata against target locations
- Display score based on solved clues

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bd7de2af988330b33d608311c4f9db